### PR TITLE
reordering of keys for course.format()

### DIFF
--- a/flask-api-unit-test/models.py
+++ b/flask-api-unit-test/models.py
@@ -151,10 +151,10 @@ class Course(db.Model):
 
     def format(self):
         return {
+            'created_at': str(self.created_at),
             'id': self.id,
             'name': self.name,
-            'semester': self.semester,
-            'created_at': self.created_at,
+            'semester': self.semester
         }
 
 


### PR DESCRIPTION
- when unittesting, comparing json output with actual object data has two issues.
- First one is json display ordering is different from the ordering in format().
- Second one is the date formating is also different.
- This will cause the tests will fail.
- This commit makes everyhing proper.. hopefully :).